### PR TITLE
DRY up RoleBindings

### DIFF
--- a/helm-charts/strimzi-kafka-operator/templates/020-RoleBinding-strimzi-cluster-operator.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/020-RoleBinding-strimzi-cluster-operator.yaml
@@ -1,24 +1,5 @@
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: RoleBinding
-metadata:
-  name: strimzi-cluster-operator
-  labels:
-    app: {{ template "strimzi.name" . }}
-    chart: {{ template "strimzi.chart" . }}
-    component: role-binding
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-subjects:
-  - kind: ServiceAccount
-    name: strimzi-cluster-operator
-    namespace: {{ .Release.Namespace }}
-roleRef:
-  kind: ClusterRole
-  name: strimzi-cluster-operator-namespaced
-  apiGroup: rbac.authorization.k8s.io
 {{- $root := . -}}
-{{- range .Values.watchNamespaces }}
+{{- range append .Values.watchNamespaces .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding

--- a/helm-charts/strimzi-kafka-operator/templates/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
@@ -1,24 +1,5 @@
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: RoleBinding
-metadata:
-  name: strimzi-cluster-operator-entity-operator-delegation
-  labels:
-    app: {{ template "strimzi.name" . }}
-    chart: {{ template "strimzi.chart" . }}
-    component: entity-operator-role-binding
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-subjects:
-  - kind: ServiceAccount
-    name: strimzi-cluster-operator
-    namespace: {{ .Release.Namespace }}
-roleRef:
-  kind: ClusterRole
-  name: strimzi-entity-operator
-  apiGroup: rbac.authorization.k8s.io
 {{- $root := . -}}
-{{- range .Values.watchNamespaces }}
+{{- range append .Values.watchNamespaces .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding

--- a/helm-charts/strimzi-kafka-operator/templates/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml
@@ -1,24 +1,5 @@
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: RoleBinding
-metadata:
-  name: strimzi-cluster-operator-topic-operator-delegation
-  labels:
-    app: {{ template "strimzi.name" . }}
-    chart: {{ template "strimzi.chart" . }}
-    component: topic-operator-role-binding
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-subjects:
-  - kind: ServiceAccount
-    name: strimzi-cluster-operator
-    namespace: {{ .Release.Namespace }}
-roleRef:
-  kind: ClusterRole
-  name: strimzi-topic-operator
-  apiGroup: rbac.authorization.k8s.io
 {{- $root := . -}}
-{{- range .Values.watchNamespaces }}
+{{- range append .Values.watchNamespaces .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding

--- a/helm-charts/strimzi-kafka-operator/templates/050-Deployment-strimzi-cluster-operator.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/050-Deployment-strimzi-cluster-operator.yaml
@@ -22,15 +22,7 @@ spec:
           imagePullPolicy: {{ .Values.image.imagePullPolicy | quote }}
           env:
             - name: STRIMZI_NAMESPACE
-              {{- if .Values.watchNamespaces -}}
-              {{- $ns := .Values.watchNamespaces -}}
-              {{- $ns := append $ns .Release.Namespace }}
-              value: {{ join "," $ns }}
-              {{- else }}
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-              {{- end }}
+              value: {{ template "strimzi.watchNamespaces" . }}
             - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
               value: {{ .Values.fullReconciliationIntervalMs | quote }}
             - name: STRIMZI_OPERATION_TIMEOUT_MS

--- a/helm-charts/strimzi-kafka-operator/templates/_helpers.tpl
+++ b/helm-charts/strimzi-kafka-operator/templates/_helpers.tpl
@@ -32,6 +32,14 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Comma delimited list of namespaces to watch
+*/}}
+{{- define "strimzi.watchNamespaces" -}}
+{{- $namespaces := append .Values.watchNamespaces .Release.Namespace -}}
+{{- join "," $namespaces | quote -}}
+{{- end -}}
+
+{{/*
 Generate a docker registry prefix or empty string.
 
 NOTE: Not currently being used.  Is this useful?


### PR DESCRIPTION
Hey @Tombar .  Here's what I came up with.  Helm Templating is really finicky, but I think this reduces a lot of complexity.

* DRY `RoleBinding` definitions
* Create template variable for `Deployment` watched namespaces config
